### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/HadoopException.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/HadoopException.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/HadoopSecurityException.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/HadoopSecurityException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/HadoopSystemConstants.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/HadoopSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/autoconfigure/HadoopAutoConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/autoconfigure/HadoopAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/autoconfigure/HadoopFsShellAutoConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/autoconfigure/HadoopFsShellAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/autoconfigure/properties/SpringHadoopProperties.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/autoconfigure/properties/SpringHadoopProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/EnableHadoop.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/EnableHadoop.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/SpringHadoopConfigs.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/SpringHadoopConfigs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/SpringHadoopConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/SpringHadoopConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/SpringHadoopConfigurerAdapter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/SpringHadoopConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/builders/HadoopConfigBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/builders/HadoopConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/builders/HadoopConfigConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/builders/HadoopConfigConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/builders/SpringHadoopConfigBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/builders/SpringHadoopConfigBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/configuration/SpringHadoopConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/annotation/configuration/SpringHadoopConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractAnnotationBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractAnnotationBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractAnnotationConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractAnnotationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractConfiguredAnnotationBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractConfiguredAnnotationBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractImportingAnnotationConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AbstractImportingAnnotationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationConfigurerAdapter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationConfigurerBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/AnnotationConfigurerBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/EnableAnnotationConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/EnableAnnotationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configuration/AutowireBeanFactoryObjectPostProcessor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configuration/AutowireBeanFactoryObjectPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configuration/ObjectPostProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configuration/ObjectPostProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/DefaultPropertiesConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/DefaultPropertiesConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/DefaultResourceConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/DefaultResourceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/DefaultSecurityConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/DefaultSecurityConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/PropertiesConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/PropertiesConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/PropertiesConfigurerAware.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/PropertiesConfigurerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/ResourceConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/ResourceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/ResourceConfigurerAware.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/ResourceConfigurerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/SecurityConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/SecurityConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/SecurityConfigurerAware.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/config/common/annotation/configurers/SecurityConfigurerAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/configuration/ConfigurationFactoryBean.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/configuration/ConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/configuration/ConfigurationUtils.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/configuration/ConfigurationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/configuration/JobConfUtils.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/configuration/JobConfUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/CustomResourceLoaderRegistrar.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/CustomResourceLoaderRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/DistCp.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/DistCp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/DistributedCacheFactoryBean.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/DistributedCacheFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FileSystemFactoryBean.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FileSystemFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FsShell.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FsShell.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FsShellPermissions.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FsShellPermissions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/HdfsResource.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/HdfsResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/HdfsResourceLoader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/HdfsResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/PrettyPrintList.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/PrettyPrintList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/PrettyPrintMap.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/PrettyPrintMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/SimplerFileSystem.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/SimplerFileSystem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/TextRecordInputStream.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/TextRecordInputStream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/security/HadoopSecurity.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/security/HadoopSecurity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/security/SecurityAuthMethod.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/security/SecurityAuthMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataStoreReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataStoreReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataStoreWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/DataWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/PartitionDataStoreWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/PartitionDataStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/StoreException.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/StoreException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/StoreSystemConstants.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/StoreSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/codec/CodecInfo.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/codec/CodecInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/codec/Codecs.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/codec/Codecs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/codec/DefaultCodecInfo.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/codec/DefaultCodecInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/EnableDataStorePartitionTextWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/EnableDataStorePartitionTextWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/EnableDataStoreTextWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/EnableDataStoreTextWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurerAdapter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/SpringDataStoreTextWriterConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/SpringDataStoreWriterConfigs.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/SpringDataStoreWriterConfigs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/builders/DataStoreTextWriterBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/builders/DataStoreTextWriterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/builders/DataStoreTextWriterConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/builders/DataStoreTextWriterConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/builders/SpringDataStoreTextWriterBuilder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/builders/SpringDataStoreTextWriterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configuration/SpringDataStoreTextWriterConfiguration.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configuration/SpringDataStoreTextWriterConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/DefaultNamingStrategyConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/DefaultNamingStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/DefaultPartitionStrategyConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/DefaultPartitionStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/DefaultRolloverStrategyConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/DefaultRolloverStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/NamingStrategyConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/NamingStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/PartitionStrategyConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/PartitionStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/RolloverStrategyConfigurer.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/config/annotation/configurers/RolloverStrategyConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/AbstractStoreEvent.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/AbstractStoreEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/DefaultStoreEventPublisher.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/DefaultStoreEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/FileWrittenEvent.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/FileWrittenEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/LoggingListener.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/LoggingListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/StoreEventPublisher.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/event/StoreEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/DateFormatMethodExecutor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/DateFormatMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/HashListMethodExecutor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/HashListMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/HashMethodExecutor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/HashMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/HashRangeMethodExecutor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/HashRangeMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MapExpressionMethods.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MapExpressionMethods.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MapPartitionKeyPropertyAccessor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MapPartitionKeyPropertyAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessageDateFormatMethodExecutor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessageDateFormatMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessageExpressionMethods.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessageExpressionMethods.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessagePartitionKeyMethodResolver.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessagePartitionKeyMethodResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessagePartitionKeyPropertyAccessor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/MessagePartitionKeyPropertyAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/PartitionKeyMethodResolver.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/PartitionKeyMethodResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/PathCombiningMethodExecutor.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/expression/PathCombiningMethodExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/AbstractDataStreamReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/AbstractDataStreamReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/AbstractSequenceFileReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/AbstractSequenceFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/DelimitedTextFileReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/DelimitedTextFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/TextFileReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/TextFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/TextSequenceFileReader.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/input/TextSequenceFileReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/AbstractDataStreamWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/AbstractDataStreamWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/AbstractPartitionDataStoreWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/AbstractPartitionDataStoreWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/AbstractSequenceFileWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/AbstractSequenceFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/DelimitedTextFileWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/DelimitedTextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/OutputStreamWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/OutputStreamWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/PartitionTextFileWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/PartitionTextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/TextFileWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/TextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/TextSequenceFileWriter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/output/TextSequenceFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/AbstractPartitionStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/AbstractPartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/DefaultPartitionKey.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/DefaultPartitionKey.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/DefaultPartitionStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/DefaultPartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/MessagePartitionStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/MessagePartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/PartitionKeyResolver.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/PartitionKeyResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/PartitionResolver.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/PartitionResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/PartitionStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/partition/PartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/AbstractSplitter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/AbstractSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/GenericSplit.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/GenericSplit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/SlopBlockSplitter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/SlopBlockSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/Split.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/Split.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/SplitLocation.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/SplitLocation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/Splitter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/Splitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/StaticBlockSplitter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/StaticBlockSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/StaticLengthSplitter.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/split/StaticLengthSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/AbstractFileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/AbstractFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/ChainedFileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/ChainedFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/CodecFileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/CodecFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/FileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/FileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/FileNamingStrategyFactory.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/FileNamingStrategyFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/RollingFileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/RollingFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/StaticFileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/StaticFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/UuidFileNamingStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/naming/UuidFileNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/AbstractRolloverStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/AbstractRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/ChainedRolloverStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/ChainedRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/NoRolloverStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/NoRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/RolloverStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/RolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/RolloverStrategyFactory.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/RolloverStrategyFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/SizeRolloverStrategy.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/strategy/rollover/SizeRolloverStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/IdleTimeoutTrigger.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/IdleTimeoutTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/InputContext.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/InputContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/InputStoreObjectSupport.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/InputStoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/LifecycleObjectSupport.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/LifecycleObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/OrderedComposite.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/OrderedComposite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/OutputContext.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/OutputContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/OutputStoreObjectSupport.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/OutputStoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/PollingTaskSupport.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/PollingTaskSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/SequenceFileWriterHolder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/SequenceFileWriterHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StoreContextUtils.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StoreContextUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StoreObjectSupport.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StoreObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StoreUtils.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StoreUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StreamsHolder.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/store/support/StreamsHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/hadoop/boot/properties/SpringHadoopPropertiesTests.java
+++ b/spring-cloud-starter-stream-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/hadoop/boot/properties/SpringHadoopPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/DataStoreWriterFactoryBean.java
+++ b/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/DataStoreWriterFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfigurationTests.java
+++ b/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkPropertiesTests.java
+++ b/spring-cloud-starter-stream-sink-hdfs/src/test/java/org/springframework/cloud/stream/app/hdfs/sink/HdfsSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 156 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).