### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FsShell.java
+++ b/spring-cloud-starter-stream-hdfs/src/main/java/org/springframework/cloud/stream/app/hdfs/hadoop/fs/FsShell.java
@@ -56,7 +56,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * HDFS FileSystem Shell supporting the 'hadoop fs/dfs [x]' commands as methods.
- * See the <a href="http://hadoop.apache.org/common/docs/stable/file_system_shell.html">official guide</a> for more information.
+ * See the <a href="https://hadoop.apache.org/common/docs/stable/file_system_shell.html">official guide</a> for more information.
  * <p>
  * This class mimics as much as possible the shell behavior yet it is meant to be used in a programmatic way,
  * that is rather then printing out information, they return object or collections that one can iterate through. If the message is


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://hadoop.apache.org/common/docs/stable/file_system_shell.html (404) with 1 occurrences migrated to:  
  https://hadoop.apache.org/common/docs/stable/file_system_shell.html ([https](https://hadoop.apache.org/common/docs/stable/file_system_shell.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).